### PR TITLE
navigate to login after password reset

### DIFF
--- a/admin/src/components/Auth/ResetPassword.tsx
+++ b/admin/src/components/Auth/ResetPassword.tsx
@@ -5,7 +5,7 @@ import { toast } from 'react-toastify';
 import * as Yup from 'yup';
 import { Formik, Field, ErrorMessage, Form } from 'formik';
 import useLoading from '../../constants/loading';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 const validationSchema = Yup.object().shape({
   password: Yup.string()
@@ -35,6 +35,7 @@ const ResetPassword = () => {
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
   const token = queryParams.get('token');
+  const navigate = useNavigate();
 
   function delay(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -56,6 +57,7 @@ const ResetPassword = () => {
       await delay(2000);
       const response = await axios.post(apiUrl, values, config);
       toast.success(response.data.message);
+      navigate('/'); // Redirect to login page after successful password reset
     } catch (error: unknown) {
       const axiosError = error as AxiosError<ResponseData>;
       toast.error(


### PR DESCRIPTION
This pull request updates the `ResetPassword` component in the `admin` application to include navigation functionality after a successful password reset. The most important changes involve adding the `useNavigate` hook and implementing a redirect to the login page.

### Navigation functionality:

* [`admin/src/components/Auth/ResetPassword.tsx`](diffhunk://#diff-7f8873ce7915c41a93c3147ca1b6dbbe518ea41c05a3aee9df815d8dc6e4c1f5L8-R8): Imported the `useNavigate` hook from `react-router-dom` to enable navigation.
* [`admin/src/components/Auth/ResetPassword.tsx`](diffhunk://#diff-7f8873ce7915c41a93c3147ca1b6dbbe518ea41c05a3aee9df815d8dc6e4c1f5R38): Added the `navigate` constant using `useNavigate` within the `ResetPassword` component.
* [`admin/src/components/Auth/ResetPassword.tsx`](diffhunk://#diff-7f8873ce7915c41a93c3147ca1b6dbbe518ea41c05a3aee9df815d8dc6e4c1f5R60): Updated the success handler to include a call to `navigate('/')`, redirecting users to the login page after a successful password reset.